### PR TITLE
Increase testing coverage and fix refresh tokens

### DIFF
--- a/hackthebox/errors.py
+++ b/hackthebox/errors.py
@@ -8,11 +8,6 @@ class AuthenticationException(HtbException):
     pass
 
 
-class UnknownSolveException(HtbException):
-    """An unknown solve type was passed"""
-    pass
-
-
 class IncorrectFlagException(HtbException):
     """An incorrect flag was submitted"""
     pass

--- a/hackthebox/htb.py
+++ b/hackthebox/htb.py
@@ -50,7 +50,6 @@ class HTBClient:
         when the current one expires
 
         """
-        # TODO: Find a way to test this
         headers = {"User-Agent": USER_AGENT}
         r = requests.post(API_BASE + "login/refresh", json={
                 "refresh_token": self._refresh_token
@@ -83,11 +82,11 @@ class HTBClient:
                 r = requests.get(self._api_base + endpoint, headers=headers)
             else:
                 r = requests.post(self._api_base + endpoint, json=json_data, data=data, headers=headers)
-            # Not sure on the exact ratelimit - loop until we don't get 429
-            if r.status_code == 429:
-                time.sleep(1)
-            else:
+            if r.status_code != 429:
                 break
+            # Not sure on the exact ratelimit - loop until we don't get 429
+            else:
+                time.sleep(0.25)
         return r.json()
 
     def __init__(self, email: str = None, password: str = None, api_base: str = API_BASE):
@@ -106,7 +105,7 @@ class HTBClient:
                 "email": email, "password": password
             }, authorized=False)
             self._access_token = data['message']['access_token']
-            self._refresh_token = data['message']['access_token']
+            self._refresh_token = data['message']['refresh_token']
 
     # noinspection PyUnresolvedReferences
     def do_search(self, search_term: str) -> "Search":

--- a/hackthebox/user.py
+++ b/hackthebox/user.py
@@ -2,7 +2,6 @@ from typing import List
 
 from . import htb
 from .solve import MachineSolve, ChallengeSolve, EndgameSolve, FortressSolve, Solve
-from .errors import UnknownSolveException
 
 
 class User(htb.HTBObject):
@@ -98,9 +97,7 @@ class User(htb.HTBObject):
                     self._activity.append(EndgameSolve(solve_item, self._client))
                 elif solve_type == 'fortress':
                     self._activity.append(FortressSolve(solve_item, self._client))
-                else:
-                    print(solve_item)
-                    raise UnknownSolveException
+
         return self._activity
 
     def __repr__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import os
 from os import getenv
 import sys
+import base64
+import json
+
 from pytest import fixture
 from hackthebox import HTBClient
 from dotenv import load_dotenv
@@ -20,4 +23,14 @@ def htb_client() -> HTBClient:
 def mock_htb_client() -> HTBClient:
     mock_api.start_mock_server()
     client = HTBClient(email="user@example.com", password="password", api_base="http://localhost:9000/api/v4/")
+    return client
+
+
+@fixture
+def expired_htb_client() -> HTBClient:
+    client = HTBClient(email=getenv("HTB_EMAIL"), password=getenv("HTB_PASSWORD"))
+    # Fake access token which will expire immediately
+    client._access_token = (base64.b64encode(json.dumps({"typ": "JWT", "alg": "RS256"}).encode()).decode() + "." +
+                            base64.b64encode(json.dumps({"aud": "0", "jti": "", "iat": 0, "nbf": 0,
+                                                         "exp": 0, "sub": "0", "scopes": []}).encode()).decode() + ".")
     return client

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -7,6 +7,8 @@ from threading import Thread
 CORRECT_CHALLENGE = "HTB{a_challenge_flag}"
 CORRECT_HASH = "30ea86803e0d85be51599c3a4e422266"
 
+has_ratelimited: bool = False
+
 
 class MockApiHandler(BaseHTTPRequestHandler):
     def _set_headers(self):
@@ -15,6 +17,14 @@ class MockApiHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
+        global has_ratelimited
+        if not has_ratelimited:
+            # Simulate ratelimit by sending a 429 once
+            self.send_response(429)
+            self.end_headers()
+            has_ratelimited = True
+            self.wfile.write(b"")
+            return
         length = int(self.headers.get('content-length'))
         message = json.loads(self.rfile.read(length))
         if self.path == "/api/v4/challenge/own":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest import raises
 from hackthebox.htb import HTBClient
 from hackthebox import errors
@@ -20,3 +19,15 @@ def test_incorrect_login():
 
 def test_get_own_user(htb_client: HTBClient):
     assert htb_client.user is not None
+
+
+def test_invalid_attr(htb_client: HTBClient):
+    """Tests that getting an invalid attr from a HTBObject
+    doesn't cause infinite recursion or similar problems"""
+    with raises(AttributeError):
+        print(htb_client.get_machine(1).nothing)
+
+
+def test_refresh_token(expired_htb_client: HTBClient):
+    """Tests the ability to refresh an expired access token"""
+    expired_htb_client.get_machine(1)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,6 +5,6 @@ def test_search(htb_client: HTBClient):
     search = htb_client.do_search("blue")
     print(search)
     # Resolve the results of the search
-    items = search.items
+    print(search.items)
     assert len(search) > 0
     print(search)


### PR DESCRIPTION
 - Fake an expired token to force refresh
 - Force a ratelimit with the mock API server to trigger the sleep
 - Remove UnknownSolveException as it should never trigger
Also fixed the refresh_token being set to the access_token, so it would not be possible to refresh.