### PR TITLE
Implement starting and stopping machines

### DIFF
--- a/examples/choose_machine.py
+++ b/examples/choose_machine.py
@@ -1,7 +1,7 @@
 import random
 
 
-def main(client):
+def main(client, _testing=False):
     machines = client.get_machines()
     print(f"Chosen Machine: {random.choice(machines)}")
 

--- a/examples/get_activity.py
+++ b/examples/get_activity.py
@@ -1,4 +1,4 @@
-def main(client):
+def main(client, _testing=False):
     print(client.user.activity)
 
 

--- a/examples/leaderboards.py
+++ b/examples/leaderboards.py
@@ -1,4 +1,4 @@
-def main(client):
+def main(client, _testing=False):
     hof = client.get_hof()
     print(hof[0])
     for i in hof:

--- a/examples/login.py
+++ b/examples/login.py
@@ -1,4 +1,4 @@
-def main(client):
+def main(client, _testing=False):
     print(client.user)
 
 

--- a/examples/spawn_challenge.py
+++ b/examples/spawn_challenge.py
@@ -1,0 +1,15 @@
+def main(client, testing=False):
+    if testing:
+        return
+    search = client.do_search("Hunting")
+    challenge = search.challenges[0]
+    challenge.start()
+    instance = challenge.instance
+    challenge.submit("HTB{fake_flag}", 20)
+    print(instance.ip, instance.port)
+    instance.stop()
+
+
+if __name__ == "__main__":
+    from base import client as example_client
+    main(example_client)

--- a/hackthebox/errors.py
+++ b/hackthebox/errors.py
@@ -42,3 +42,8 @@ class IncorrectArgumentException(HtbException):
     def __init__(self, reason: str):
         self.reason = reason
     pass
+
+
+class NoDockerException(HtbException):
+    """A challenge was 'started' when no Docker is available"""
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ def htb_client() -> HTBClient:
 
 @fixture(scope="session")
 def mock_htb_client() -> HTBClient:
-    mock_api.start_mock_server()
-    client = HTBClient(email="user@example.com", password="password", api_base="http://localhost:9000/api/v4/")
+    port = mock_api.start_mock_server()
+    client = HTBClient(email="user@example.com", password="password", api_base=f"http://localhost:{port}/api/v4/")
     return client
 
 

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -49,6 +49,20 @@ class MockApiHandler(BaseHTTPRequestHandler):
                     "refresh_token": "FakeToken"
                 }
             }).encode())
+        elif self.path == "/api/v4/challenge/start":
+            if message['challenge_id'] == 144:
+                self._set_headers()
+                self.wfile.write(json.dumps({"message": "Instance Created!", "id": "pwnhunting-83743",
+                                             "port": 31475, "ip": "10.10.10.10"}).encode()
+                                 )
+            else:
+                self._set_headers()
+                self.wfile.write(json.dumps({"message": "Incorrect Parameters"}).encode())
+
+        elif self.path == "/api/v4/challenge/stop":
+            self._set_headers()
+            self.wfile.write(json.dumps({"message": "Container Stopped"}).encode())
+
         elif re.match(r"/api/v4/endgame/\d+/flag", self.path):
             if message['flag'] == CORRECT_HASH:
                 self._set_headers()

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -84,7 +84,8 @@ class MockApiHandler(BaseHTTPRequestHandler):
 
 
 def start_mock_server():
-    mock_server = HTTPServer(('localhost', 9000), MockApiHandler)
+    mock_server = HTTPServer(('localhost', 0), MockApiHandler)
     mock_server_thread = Thread(target=mock_server.serve_forever)
     mock_server_thread.setDaemon(True)
     mock_server_thread.start()
+    return mock_server.server_address[1]

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -1,5 +1,5 @@
 from pytest import raises
-from hackthebox import HTBClient
+from hackthebox import HTBClient, NoDockerException
 
 
 def test_get_challenge(htb_client: HTBClient):
@@ -37,3 +37,20 @@ def test_challenge_authors(htb_client: HTBClient):
     author1, author2 = challenge.authors
     assert author1.name == "makelarisjr"
     assert author2.name == "makelaris"
+
+
+def test_start_challenge(htb_client: HTBClient, mock_htb_client: HTBClient):
+    """Tests the ability to start an instance of a challenge"""
+    # Use mock API for the starting so we don't spam
+    bad_challenge = htb_client.get_challenge(1)
+    bad_challenge._client = mock_htb_client
+    with raises(NoDockerException):
+        bad_challenge.start()
+
+    # TODO: Test loading a started challenge on the API
+    # Will require the mock API tracking the challenges which have 'started'
+    good_challenge = htb_client.get_challenge(144)
+    good_challenge._client = mock_htb_client
+    instance = good_challenge.start()
+    assert instance.ip is not None
+    instance.stop()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,4 +12,6 @@ def example_fns():
 
 @pytest.mark.parametrize("example_fn", example_fns())
 def test_example(htb_client, example_fn):
-    example_fn.main(htb_client)
+    # 2nd param is `testing` - some examples shouldn't
+    # be run as part of the test suite
+    example_fn.main(htb_client, True)


### PR DESCRIPTION
Due to spam concerns, the instance starting/stopping functionality is only tested via the mock API. Manual testing should be done to check it still works. If a Challenge is stopped, `self.instance` won't return None, but instead an Instance object with all properties zeroed.