### PR TITLE
Implement challenge downloads

### DIFF
--- a/hackthebox/challenge.py
+++ b/hackthebox/challenge.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from typing import List
 from datetime import datetime
+import os
 
 import dateutil.parser
 
 from . import htb
-from .errors import IncorrectFlagException, IncorrectArgumentException, NoDockerException
+from .errors import IncorrectFlagException, IncorrectArgumentException, NoDockerException, NoDownloadException
 
 
 class Challenge(htb.HTBObject):
@@ -95,6 +96,24 @@ class Challenge(htb.HTBObject):
         # TODO: Handle failure to start
         self.instance = DockerInstance(instance['ip'], instance['port'], self.id, self._client, instance['id'])
         return self.instance
+
+    def download(self, path=None) -> str:
+        """
+
+        Args:
+            path: The name of the zipfile to download to. If none is provided, it is saved to the current directory.
+
+        Returns: The path of the file
+
+        """
+        if not self.has_download:
+            raise NoDownloadException
+        if path is None:
+            path = os.path.join(os.getcwd(), f"{self.name}.zip")
+        data = self._client.do_request(f"challenge/download/{self.id}", download=True)
+        with open(path, 'wb') as f:
+            f.write(data)
+        return path
 
     # noinspection PyUnresolvedReferences
     @property

--- a/hackthebox/errors.py
+++ b/hackthebox/errors.py
@@ -52,3 +52,8 @@ class IncorrectArgumentException(HtbException):
 class NoDockerException(HtbException):
     """A challenge was 'started' when no Docker is available"""
     pass
+
+
+class NoDownloadException(HtbException):
+    """A challenge was 'downloaded' when no download is available"""
+    pass

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -1,7 +1,7 @@
 import os
 
 from pytest import raises
-from hackthebox import HTBClient, NoDockerException
+from hackthebox import HTBClient, NoDockerException, NoDownloadException
 
 
 def test_get_challenge(htb_client: HTBClient):
@@ -63,3 +63,5 @@ def test_download_challenge(htb_client: HTBClient):
     path = htb_client.get_challenge(1).download()
     assert os.path.exists(path)
     os.remove(path)
+    with raises(NoDownloadException):
+        htb_client.get_challenge(143).download()

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -1,3 +1,5 @@
+import os
+
 from pytest import raises
 from hackthebox import HTBClient, NoDockerException
 
@@ -54,3 +56,10 @@ def test_start_challenge(htb_client: HTBClient, mock_htb_client: HTBClient):
     instance = good_challenge.start()
     assert instance.ip is not None
     instance.stop()
+
+
+def test_download_challenge(htb_client: HTBClient):
+    """Tests the ability to download a challenge"""
+    path = htb_client.get_challenge(1).download()
+    assert os.path.exists(path)
+    os.remove(path)


### PR DESCRIPTION
Challenges with a download can now be downloaded to a given path. Attempting to 'download' a challenge without this option will raise an error.