### PR TITLE
Download ratelimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] 05/03/2021
+### Fixed
+- Ratelimited challenge downloads to 1 per 30 seconds
+
 ## [0.4.0] 05/03/2021
 ### Added
-- Added the ability to download challenges (with a download)
+- Added the ability to download challenges (with a download available)
 
 ## [0.3.1] 03/03/2021
 ### Fixed

--- a/hackthebox/constants.py
+++ b/hackthebox/constants.py
@@ -1,3 +1,3 @@
 API_BASE = "https://www.hackthebox.eu/api/v4/"
-USER_AGENT = "htb-api/0.01"
+USER_AGENT = "htb-api/0.4.1"
 DOWNLOAD_COOLDOWN = 30

--- a/hackthebox/constants.py
+++ b/hackthebox/constants.py
@@ -1,2 +1,3 @@
 API_BASE = "https://www.hackthebox.eu/api/v4/"
 USER_AGENT = "htb-api/0.01"
+DOWNLOAD_COOLDOWN = 30

--- a/hackthebox/errors.py
+++ b/hackthebox/errors.py
@@ -57,3 +57,10 @@ class NoDockerException(HtbException):
 class NoDownloadException(HtbException):
     """A challenge was 'downloaded' when no download is available"""
     pass
+
+
+class RateLimitException(HtbException):
+    """An internal ratelimit to prevent spam was violated"""
+    def __init__(self, message):
+        print(message)
+        super().__init__(message)

--- a/hackthebox/htb.py
+++ b/hackthebox/htb.py
@@ -35,6 +35,8 @@ class HTBClient:
 
             from hackthebox import HTBClient
             client = HTBClient(email="user@example.com", password="S3cr3tP455w0rd!")
+    Attributes:
+        challenge_cooldown: Time when next download is allowed
 
     """
     # noinspection PyUnresolvedReferences
@@ -42,6 +44,7 @@ class HTBClient:
     _access_token: str = None
     _refresh_token: str = None
     _api_base: str = None
+    challenge_cooldown: int = 0
 
     def _refresh_access_token(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="PyHackTheBox",
-    version="0.4.0",
+    version="0.4.1",
     author="clubby789@github.com",
     author_email="clubby789@gmail.com",
     description="A wrapper for the Hack The Box API.",

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -77,6 +77,11 @@ class MockApiHandler(BaseHTTPRequestHandler):
             else:
                 self._set_headers()
                 self.wfile.write(json.dumps({"message": "Wrong flag"}).encode())
+        elif re.match(r"/api/v4/challenge/download/\d+", self.path):
+            self.send_response(200)
+            self.send_header('Content-type', 'application/zip')
+            self.end_headers()
+            self.wfile.write(b"Not really zip data!")
 
     def log_message(self, fmt, *args):
         # Silence logging

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -58,14 +58,19 @@ def test_start_challenge(htb_client: HTBClient, mock_htb_client: HTBClient):
     instance.stop()
 
 
-def test_download_challenge(htb_client: HTBClient):
+def test_download_challenge(htb_client: HTBClient, mock_htb_client: HTBClient):
     """Tests the ability to download a challenge"""
-    path = htb_client.get_challenge(1).download()
+    downloadable = htb_client.get_challenge(1)
+    not_downloadable = htb_client.get_challenge(143)
+    downloadable._client = mock_htb_client
+    not_downloadable._client = mock_htb_client
+
+    path = downloadable.download()
     assert os.path.exists(path)
     os.remove(path)
-    htb_client.challenge_cooldown = 253407876721
+    downloadable._client.challenge_cooldown = 253407876721
     # The year 10,000 - should be fine
     with raises(RateLimitException):
-        htb_client.get_challenge(1).download()
+        downloadable.download()
     with raises(NoDownloadException):
-        htb_client.get_challenge(143).download()
+        not_downloadable.download()

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -1,7 +1,7 @@
 import os
 
 from pytest import raises
-from hackthebox import HTBClient, NoDockerException, NoDownloadException
+from hackthebox import HTBClient, NoDockerException, NoDownloadException, RateLimitException
 
 
 def test_get_challenge(htb_client: HTBClient):
@@ -63,5 +63,9 @@ def test_download_challenge(htb_client: HTBClient):
     path = htb_client.get_challenge(1).download()
     assert os.path.exists(path)
     os.remove(path)
+    htb_client.challenge_cooldown = 253407876721
+    # The year 10,000 - should be fine
+    with raises(RateLimitException):
+        htb_client.get_challenge(1).download()
     with raises(NoDownloadException):
         htb_client.get_challenge(143).download()


### PR DESCRIPTION
By request, adds a 1 per 30 second ratelimit to downloading challenges, and tests this using the mock, rather than real, API.
Closes #35  