### PR TITLE
fixed error handling on token refresh

### DIFF
--- a/hackthebox/htb.py
+++ b/hackthebox/htb.py
@@ -74,7 +74,7 @@ class HTBClient:
             "refresh_token": self._refresh_token
         }, headers=headers)
         data = r.json()['message']
-        if data == "Unauthenticated":
+        if data.startswith("Unauthenticated"):
             raise AuthenticationException
         self._access_token = data['access_token']
         self._refresh_token = data['refresh_token']


### PR DESCRIPTION
When using `cache` on `HTBClient`, I get a crash after coming back after several hours. The crash is in `_refresh_access_token`, where `data` is "Unauthenticated." (with a trailing "."), which is missing the failure condition:
```
(Pdb) !r.text
'{"message":"Unauthenticated."}'
(Pdb) data
'Unauthenticated.'
```
Not sure if there's a case where it doesn't send the period, so adjusting so that it handles both.