### PR TITLE
handle no current lab when RA is closed

### DIFF
--- a/hackthebox/htb.py
+++ b/hackthebox/htb.py
@@ -448,6 +448,8 @@ class HTBClient:
         else:
             data = connections['lab']['assigned_server']
 
+        if not data:
+            return None
         return VPNServer(data, self)
 
     # noinspection PyUnresolvedReferences


### PR DESCRIPTION
Handle the case where there is no current RA server:

```
>>> c.get_current_vpn_server()
<VPN Server 'US VIP 3'>
>>> c.get_current_vpn_server(release_arena=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oxdf/htbcli/venv/lib/python3.8/site-packages/hackthebox/htb.py", line 451, in get_current_vpn_server
    return VPNServer(data, self)
  File "/home/oxdf/htbcli/venv/lib/python3.8/site-packages/hackthebox/vpn.py", line 50, in __init__
    self.id = data["id"]
TypeError: 'NoneType' object is not subscriptable
```

In this case, `data` comes back as None, so just return None in that case.